### PR TITLE
Update standard controller to include namespace

### DIFF
--- a/src/pages/RecurringDonations_AddDonationsBTN.page
+++ b/src/pages/RecurringDonations_AddDonationsBTN.page
@@ -1,1 +1,1 @@
-<apex:page standardController="Recurring_Donation__c" action="{! urlFor('/apex/npsp__RD_AddDonationsBTN?id=' + Recurring_Donation__c.Id) }" />
+<apex:page standardController="npe03__Recurring_Donation__c" action="{! urlFor('/apex/npsp__RD_AddDonationsBTN?id=' + Recurring_Donation__c.Id) }" />


### PR DESCRIPTION
Without the namespace specified, people using legacy unmanaged packages are not able to uninstall them.