### PR TITLE
Fix release prefix

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -5,4 +5,4 @@ project:
         namespace: npe03
         api_version: 36.0
     git:
-        release: rel/
+        prefix_release: rel/


### PR DESCRIPTION
Minor configuration change for CumulusCI 2.  This also changes the builds to run on https://mrbelvedereci.herokuapp.com
